### PR TITLE
Relax version constraints

### DIFF
--- a/network-bsd.cabal
+++ b/network-bsd.cabal
@@ -21,7 +21,7 @@ description:
   necessary, add @network-bsd@ to your dependencies like so:
   .
   > library
-  >     build-depends: network     >= 2.7 && < 3.1
+  >     build-depends: network     >= 2.7 && < 3.2
   >                  , network-bsd >= 2.7 && < 2.9
   .
   I.e. you can control the version of the @network@ package
@@ -75,7 +75,8 @@ library
                -- with the bounds to avoid leaking through API
                -- changes that aren't reflected in `network-bsd`'s
                -- API version.
-               , network >= 3.0.0.0 && < 3.0.1
+               , network (>= 3.0.0.0 && < 3.0.2)
+                      || (>= 3.1.0.0 && < 3.1.1)
   build-tools: hsc2hs >= 0.67 && < 0.69
   ghc-options: -Wall
 


### PR DESCRIPTION
I'm just copying the recommendation that was never applied in haskell#4 since it's been open almost 1 year now.