### PR TITLE
Update cabal file to what is currently on Hackage

### DIFF
--- a/network-bsd.cabal
+++ b/network-bsd.cabal
@@ -75,7 +75,8 @@ library
                -- with the bounds to avoid leaking through API
                -- changes that aren't reflected in `network-bsd`'s
                -- API version.
-               , network >= 3.0.0.0 && < 3.0.1
+               , network (>= 3.0.0.0 && < 3.0.2) 
+                      || (>= 3.1.0.0 && < 3.1.2)
   build-tools: hsc2hs >= 0.67 && < 0.69
   ghc-options: -Wall
 


### PR DESCRIPTION
There seem to have been some metadata revisions that never made it back upstream.